### PR TITLE
Handle Optional Query Param

### DIFF
--- a/fastapi_gateway/utils/query.py
+++ b/fastapi_gateway/utils/query.py
@@ -21,6 +21,10 @@ async def unzip_query_params(
         response_query_params = {}
         for key in necessary_params:
             value = all_params.get(key)
+
+            if value is None:
+                continue
+            
             serialized_dict = await serialize_query_content(key=key, value=value)
             response_query_params.update(serialized_dict)
         return response_query_params


### PR DESCRIPTION
Hi, dotX12! 

I am a Korean developer who is using the fastapi-gateway library.

![image](https://github.com/dotX12/fastapi-gateway/assets/94329093/96e13110-3e74-4b6c-8a0e-162f91c706b3)
![image (1)](https://github.com/dotX12/fastapi-gateway/assets/94329093/a6ca99c1-fc71-4e44-9e52-edc63f934611)

When using Optional Query Param as the image above, An error occurred if an API request was made without the Optional Query Param.

I modified it so that the key-value is not added to the response_query_param dict if the Optional Query Param is not entered.

 